### PR TITLE
Add persistent portfolio support

### DIFF
--- a/portfolio.json
+++ b/portfolio.json
@@ -1,0 +1,53 @@
+{
+    "cash": 1000.0,
+    "margin_requirement": 0.0,
+    "margin_used": 0.0,
+    "positions": {
+        "AAPL": {
+            "long": 0,
+            "short": 0,
+            "long_cost_basis": 0.0,
+            "short_cost_basis": 0.0,
+            "short_margin_used": 0.0
+        },
+        "MSFT": {
+            "long": 0,
+            "short": 0,
+            "long_cost_basis": 0.0,
+            "short_cost_basis": 0.0,
+            "short_margin_used": 0.0
+        },
+        "NVDA": {
+            "long": 0,
+            "short": 0,
+            "long_cost_basis": 0.0,
+            "short_cost_basis": 0.0,
+            "short_margin_used": 0.0
+        },
+        "TSLA": {
+            "long": 0,
+            "short": 0,
+            "long_cost_basis": 0.0,
+            "short_cost_basis": 0.0,
+            "short_margin_used": 0.0
+        }
+    },
+    "realized_gains": {
+        "AAPL": {
+            "long": 0.0,
+            "short": 0.0
+        },
+        "MSFT": {
+            "long": 0.0,
+            "short": 0.0
+        },
+        "NVDA": {
+            "long": 0.0,
+            "short": 0.0
+        },
+        "TSLA": {
+            "long": 0.0,
+            "short": 0.0
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- load existing portfolio from `portfolio.json` and ensure requested tickers exist
- save updated portfolio after hedge fund run
- include example `portfolio.json` file

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896d3075c10832cac2672da2dcbfe7c